### PR TITLE
move rstudio prefs creation to end of build process

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -7,3 +7,6 @@ playwright install chromium
 
 # https://github.com/berkeley-dsep-infra/datahub/issues/5827
 git config --system pull.rebase false
+
+mkdir -p ${HOME}/.config/rstudio
+cp rstudio-prefs.json ${HOME}/.config/rstudio

--- a/start
+++ b/start
@@ -2,6 +2,4 @@
 
 # See https://jira-secure.berkeley.edu/browse/DH-305
 export PLAYWRIGHT_BROWSERS_PATH=${CONDA_DIR}
-mkdir -p ${HOME}/.config/rstudio
-cp rstudio-prefs.json ${HOME}/.config/rstudio
 exec "$@"


### PR DESCRIPTION
my 'guess' is that if we populate the rstudio prefs before installing rstudio that they might be getting clobbered.  this PR moves that process from `start` to `postBuild` and runs at the very end of the image build.

https://github.com/cal-icor/base-user-image/issues/41