### PR TITLE
finally got rstudio prefs working

### DIFF
--- a/rstudio-config/rstudio/rstudio-prefs.json
+++ b/rstudio-config/rstudio/rstudio-prefs.json
@@ -1,0 +1,9 @@
+{
+    "initial_working_directory": "~",
+    "auto_save_on_blur": true,
+    "auto_save_on_idle": "commit",
+    "posix_terminal_shell": "bash",
+    "default_project_location": "~",
+    "restore_last_project": false,
+    "auto_save_idle_ms": 500
+}

--- a/start
+++ b/start
@@ -2,4 +2,5 @@
 
 # See https://jira-secure.berkeley.edu/browse/DH-305
 export PLAYWRIGHT_BROWSERS_PATH=${CONDA_DIR}
+export XDG_CONFIG_HOME=${REPO_DIR}/rstudio-config
 exec "$@"


### PR DESCRIPTION
resoloves https://github.com/cal-icor/base-user-image/issues/41

i created a subdir called `rstudio-prefs`, which stores the pre-generated rstudio prefs (obvs).  confirmed w/a local build that prefs are pulled in to rstudio when launched and that it's updated when prefs are added/changed.

this will need to be manually tested on a `staging` hub before being deployed to all other hubs.