### PR TITLE
adding dnstools for general usefulness with debugging

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -48,4 +48,5 @@ libxrandr2
 libgbm1
 libasound2
 
+dnstools
 net-tools

--- a/apt.txt
+++ b/apt.txt
@@ -48,5 +48,5 @@ libxrandr2
 libgbm1
 libasound2
 
-dnstools
+dnsutils
 net-tools


### PR DESCRIPTION
this ~~will~~ could help us get to the bottom of https://github.com/cal-icor/docs/issues/31 by allowing users who can't connect to our docs to use `dig` from a jupyter terminal.
