### PR TITLE
adding duckdb+jupysql

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,11 @@ dependencies:
   - python==3.11.*
   - pip==25.1.1
 
+  # database tooling
+  - duckdb==1.3.2
+  - duckdb-engine==0.15.0
+  - jupysql==0.11.1
+
   # r2d installs jupyter-rsession-proxy, but in the base python env, not in the updated one
   - jupyter-rsession-proxy==2.3.0
 


### PR DESCRIPTION
work in progress for https://github.com/cal-icor/csumb-user-image/issues/46

add basic sql/database functionality to the base user image.  if this isn't sufficient for the above issue, we might consider creating a new image w/more functionality and potentially a new hub w/a mysql database sidecar container.

i've built this image locally and was able to perform the following (successful) tests:
<img width="1245" height="1178" alt="image" src="https://github.com/user-attachments/assets/34a83241-99e2-412a-b7e3-2f28e2f1475b" />

@juefish let me know what you think!