### PR TITLE
create the .Renviron file w/CONDA_DIR specified

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -28,3 +28,5 @@ for x in \
   ; do
     code-server --extensions-dir ${VSCODE_EXTENSIONS} --install-extension $x
 done
+
+echo ${CONDA_DIR} >> .Renviron

--- a/postBuild
+++ b/postBuild
@@ -29,4 +29,4 @@ for x in \
     code-server --extensions-dir ${VSCODE_EXTENSIONS} --install-extension $x
 done
 
-echo ${CONDA_DIR} >> .Renviron
+echo "CONDA_DIR=${CONDA_DIR}" >> .Renviron


### PR DESCRIPTION
resolves https://github.com/cal-icor/base-user-image/issues/69

this was tested on my workstation.  before the change i couldn't open a terminal in Rstudio.  with this change, i was able to.

however, i am unsure if this is actually the Right Solution[tm] and just a Band Aid[tm].

@ryanlovett @sean-morris any thoughts on this?