### PR TITLE
update workflow to check common.yaml for image information

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -92,8 +92,8 @@ jobs:
 
       - name: Update the tag for any deployments that use this image
         run: |
-          for deployment in $(grep -lr ${IMAGE} deployments/); do
-            old_hash=$(grep ${IMAGE} ${deployment} | awk -F":" '{print $3}')
+          for deployment in $(grep -lr ${IMAGE} deployments/**/config/common.yaml); do
+            old_hash=$(grep -hA1 ${IMAGE} ${deployment} | grep tag: | awk '{print$2}')
             new_hash=${IMAGE_TAG}
             sed -i -e "s,${IMAGE}:${old_hash},${IMAGE}:${new_hash},g" ${deployment}
             echo "Updated ${deployment} with new image tag ${new_hash}"


### PR DESCRIPTION
this will be required when https://github.com/berkeley-dsep-infra/hubploy/issues/126 is merged (along w/the soon-to-be-crafted PR that moves our image specs from `hubploy.yaml` to `common.yaml`).

instead of checking `hubploy.yaml`, check that deployments `common.yaml` for the image name, grab the line below (which will *always* need to be `tag:`) and store the old tag hash.

this needs some more testing before merge, which i'll do monday morning.  i will also need to modify https://github.com/cal-icor/csumb-user-image/blob/main/.github/workflows/build-push-create-pr.yaml when i'm happy with the changes here.

@yijunge-ucb 