### PR TITLE
automatic cancelling of existing image builds when a new commit is pushed

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -12,6 +12,10 @@ on:
       - '.github/**'
       - 'images/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -10,6 +10,10 @@ on:
       - '.github/**'
       - 'images/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
it doesn't make sense to have X image builds running with X commits being pushed to a PR.  now, if a build is running and a new commit is pushed to the branch or PR, the original build is cancelled when the new one fires up.