### PR TITLE
fix pysqlite error on user image spawn

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - notebook==7.5.0
   - python==3.11.*
   - pip==25.1.1
+  - sqlite==3.51.1
 
   # r2d installs jupyter-rsession-proxy, but in the base python env, not in the updated one
   - jupyter-rsession-proxy==2.3.0


### PR DESCRIPTION
this was popping up in my user pod logs when i tried to log in to a hub:

```
ModuleNotFoundError: No module named 'pysqlite2'
```

this will fix it