### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 90
     env:
       DOCKER_CONFIG: $HOME/.docker


### PR DESCRIPTION
Potential fix for [https://github.com/cal-icor/base-user-image/security/code-scanning/3](https://github.com/cal-icor/base-user-image/security/code-scanning/3)

In general, fix this by explicitly setting `permissions` for the job (or at the workflow root) so the `GITHUB_TOKEN` has only the access needed. For `build-and-push`, no GitHub write actions occur, so `contents: read` is a safe minimal setting.

The best targeted change is to add a `permissions` block under the `build-and-push` job definition, just below `runs-on: ubuntu-latest` (line 21). This will override repo defaults for that job only, while leaving the existing, broader permissions for `update-deployment-image-tag` unchanged. No imports, methods, or other definitions are needed, as this is purely a YAML configuration change. The new block should be:

```yaml
    permissions:
      contents: read
```

This confines the `GITHUB_TOKEN` for `build-and-push` to read-only repository contents, which is sufficient for `actions/checkout@v4` and aligns with the CodeQL recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
