### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -10,6 +10,9 @@ on:
       - '.github/**'
       - 'images/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/cal-icor/base-user-image/security/code-scanning/2](https://github.com/cal-icor/base-user-image/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block to scope down the `GITHUB_TOKEN` to the least privileges needed. For this workflow, the steps only read repository content (via `actions/checkout`) and run local build/test commands; they do not push commits, create releases, or modify issues/PRs. Therefore, `contents: read` is sufficient.

The best minimal change is to add a workflow-level `permissions` block near the top of `.github/workflows/build-test-image.yaml`, so it applies to all jobs (currently only `test-build`). This avoids duplicating configuration and does not alter job behavior, since none of the steps require write access. Specifically, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (line 12) and before `concurrency:` (line 13). No imports or extra methods are needed, as this is GitHub Actions YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
