### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -2,6 +2,9 @@ name: "Yaml lint"
 on:
   - pull_request  # yamllint disable-line rule:truthy
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cal-icor/base-user-image/security/code-scanning/1](https://github.com/cal-icor/base-user-image/security/code-scanning/1)

In general, the fix is to explicitly restrict `GITHUB_TOKEN` permissions in the workflow, either at the root level (applies to all jobs) or within the specific job. For a lint-only workflow that only needs to read the repository contents, `contents: read` is sufficient.

The best minimal fix here is to add a `permissions` block at the top (root) level of `.github/workflows/yaml-lint.yaml`, just below the `on:` section. This will apply to all jobs in the workflow (currently just `lint`) and restrict the `GITHUB_TOKEN` to read-only for repository contents. No other permissions (issues, pull-requests, etc.) are needed because the job only checks out code and runs a local tool. No additional imports or external dependencies are required; it is purely a YAML configuration change.

Concretely, modify `.github/workflows/yaml-lint.yaml` by inserting:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (after line 4, before line 5 in the snippet you provided). This change does not alter existing functionality, as all current steps remain unchanged and do not rely on any write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
