### PR TITLE
fixing a quarto bug where it looks for deno in the wrong location

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -31,10 +31,6 @@ done
 
 # Create a symbolic link for 'deno' in the specified directory structure
 CONDA_PREFIX=/srv/conda/envs/notebook
-if [[ -z "$CONDA_PREFIX" ]]; then 
-    echo "CONDA_PREFIX is not set. Please activate your Conda environment."
-    exit 1
-fi
 
 # Define the target directory for the symbolic link
 TARGET_DIR="$CONDA_PREFIX/bin/tools/x86_64"


### PR DESCRIPTION
users are seeing the following error:

<img width="1949" height="559" alt="image" src="https://github.com/user-attachments/assets/d0fb2725-7f21-4353-bb3e-88f54308ffdc" />

this should fix it!