### PR TITLE
update base image to ubuntu 24.04LTS

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: write
-    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.1.2
+    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.2.1
     with:
       image: ${{ vars.IMAGE}}
       hub: ${{ vars.HUB }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   test-build:
-    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.1.1
+    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.2.1

--- a/apt.txt
+++ b/apt.txt
@@ -46,7 +46,7 @@ libxdamage1
 libxfixes3
 libxrandr2
 libgbm1
-libasound2
+liboss4-salsa-asound2
 
 dnsutils
 net-tools

--- a/apt.txt
+++ b/apt.txt
@@ -30,6 +30,7 @@ ruby
 
 # Other niceties for command-line work and life
 rsync
+tree
 
 # playwright deps https://jira-secure.berkeley.edu/browse/DH-325
 libnss3

--- a/environment.yml
+++ b/environment.yml
@@ -49,7 +49,7 @@ dependencies:
 
   # pip installed packages, conda is preferred
   - pip:
-    - jupyterlab-a11y-checker==0.2.5
+    - jupyterlab-a11y-checker==0.2.7
 
     # useful for debugging python package issues
     - pip-tree==4.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - jupyterlab_rise==0.43.1
   - jupytext==1.16.6
   - notebook==7.5.6
-  - python==3.11.*
+  - python==3.12.*
   - pip==25.1.1
   - regex==2025.11.3
   - sqlite==3.51.1

--- a/environment.yml
+++ b/environment.yml
@@ -62,4 +62,4 @@ dependencies:
     - otter-grader==6.1.3
 
     # nbgitpuller pre-release
-    - nbgitpuller==1.3.0b1
+    - nbgitpuller==1.3.0

--- a/postBuild
+++ b/postBuild
@@ -8,6 +8,10 @@ playwright install chromium
 # https://github.com/berkeley-dsep-infra/datahub/issues/5827
 git config --system pull.rebase false
 
+# set the location for the default rstudio prefs
+mkdir -p ${REPO_DIR}/rstudio/dictionaries
+cp -p rstudio-config/rstudio/rstudio-prefs.json ${REPO_DIR}/rstudio/
+
 # overrides.json is a file that jupyterlab reads to determine some settings
 # 1) remove the 'create shareable link' option from the filebrowser context menu
 mkdir -p ${NB_PYTHON_PREFIX}/share/jupyter/lab/settings


### PR DESCRIPTION
this pr also updates the shared workflows to use the latest tag (https://github.com/cal-icor/shared-workflows/releases/tag/0.2.1) which uses the new repo2docker as per https://github.com/cal-icor/shared-workflows/pull/6